### PR TITLE
Move usr/ in the cmake prefix

### DIFF
--- a/Build/Linux/GCC/CMakeLists.txt
+++ b/Build/Linux/GCC/CMakeLists.txt
@@ -82,9 +82,9 @@ target_link_libraries(cieunlockpin ciepki)
 target_link_libraries(ciechangepin ciepki)
 
 install(TARGETS ciepki cieunlockpin ciechangepin
-	ARCHIVE DESTINATION usr/lib
-	LIBRARY DESTINATION usr/lib
-	RUNTIME DESTINATION usr/bin)
+	ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION lib
+	RUNTIME DESTINATION bin)
 #install(FILES ${CMAKE_BINARY_DIR}/ciepki.pc
 #	DESTINATION usr/share/pkgconfig)
 

--- a/Build/Linux/GCC/makedist.sh
+++ b/Build/Linux/GCC/makedist.sh
@@ -5,7 +5,7 @@ BUILD_DIR="$PROJ_ROOT/build"
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
-cmake -DCMAKE_MODULE_PATH=$PROJ_ROOT -DCMAKE_INSTALL_PREFIX=$PROJ_ROOT/dist $PROJ_ROOT
+cmake -DCMAKE_MODULE_PATH=$PROJ_ROOT -DCMAKE_INSTALL_PREFIX=$PROJ_ROOT/dist/usr $PROJ_ROOT
 #/Build/Linux/GCC
 make && make install/strip
 find $PROJ_ROOT/dist/ -type d | xargs chmod 755


### PR DESCRIPTION
Usually the prefix is set to /usr or /usr/local, so adding usr/ again to
the prefix path is redundant. Also some distributions (GoboLinux, NixOS,
GuixSD) do not use /usr as prefix.

---

Non ho potuto testare ancora se la pacchettizzazione deb funziona ancora perché non sono su un sistema debian-based. Nei prossimi giorni proverò su una macchina virtuale.