### PR TITLE
Corregge 3 bug che rendono impossibile il login con CIE su Linux - Should fix #91

### DIFF
--- a/TestCIE/UUCByteArray.cpp
+++ b/TestCIE/UUCByteArray.cpp
@@ -112,7 +112,7 @@ UUCByteArray::~UUCByteArray()
 	//GlobalFree(m_pbtContent);
 	free(m_pbtContent);
 	if(m_szHex)
-		delete m_szHex;
+		delete[] m_szHex;
 }
 
 long UUCByteArray::load(const char* szHexString)
@@ -288,7 +288,7 @@ const char* UUCByteArray::toHexString(int nSize)
 {
 	if(m_szHex)
 	{
-		delete m_szHex;
+		delete[] m_szHex;
 		m_szHex = NULL;
 	}
 
@@ -313,7 +313,7 @@ const char* UUCByteArray::toHexString(int nSize)
 	}
 	catch(...)
 	{
-		delete m_szHex;
+		delete[] m_szHex;
 		m_szHex = NULL;
 		throw -3L;//new UUCException("UUCByteArray:toHexString:Access Violation");
 	}

--- a/cie-pkcs11/PKCS11/Mechanism.cpp
+++ b/cie-pkcs11/PKCS11/Mechanism.cpp
@@ -10,7 +10,11 @@
 
 static BYTE SHA1_RSAcode[]={0x30,0x21,0x30,0x09,0x06,0x05,0x2b,0x0e,0x03,0x02,0x1a,0x05,0x00,0x04,0x14};
 static BYTE MD5_RSAcode[]={0x30,0x20,0x30,0x0C,0x06,0x08,0x2A,0x86,0x48,0x86,0xF7,0x0D,0x02,0x05,0x05,0x00,0x04,0x10};
+// RFC 8017 sezione 9.2: prefisso DigestInfo per SHA-256. Mancava, e
+// CDigestSHA256::DigestInfo() restituiva quello di SHA-1.
+static BYTE SHA256_RSAcode[]={0x30,0x31,0x30,0x0d,0x06,0x09,0x60,0x86,0x48,0x01,0x65,0x03,0x04,0x02,0x01,0x05,0x00,0x04,0x20};
 static ByteArray baSHA1DigestInfo(SHA1_RSAcode,sizeof(SHA1_RSAcode));
+static ByteArray baSHA256DigestInfo(SHA256_RSAcode,sizeof(SHA256_RSAcode));
 static ByteArray baMD5DigestInfo(MD5_RSAcode,sizeof(MD5_RSAcode));
 
 namespace p11 {
@@ -113,7 +117,7 @@ namespace p11 {
 	/* ******************** */
 	/*		   SHA256	        */
 	/* ******************** */
-	CDigestSHA256::CDigestSHA256(std::shared_ptr<CSession> Session) : CDigest(CKM_SHA_1, std::move(Session)) {}
+	CDigestSHA256::CDigestSHA256(std::shared_ptr<CSession> Session) : CDigest(CKM_SHA256, std::move(Session)) {}
 	CDigestSHA256::~CDigestSHA256() {}
 
 	void CDigestSHA256::DigestInit() {
@@ -142,7 +146,7 @@ namespace p11 {
 
 	ByteArray CDigestSHA256::DigestInfo() {
 		init_func
-			return baSHA1DigestInfo;
+			return baSHA256DigestInfo;
 	}
 
 	ByteDynArray  CDigestSHA256::DigestGetOperationState()

--- a/cie-pkcs11/PKCS11/Slot.cpp
+++ b/cie-pkcs11/PKCS11/Slot.cpp
@@ -466,8 +466,13 @@ namespace p11 {
 		pInfo->ulRwSessionCount = dwRWSessCount;
 		pInfo->ulMaxRwSessionCount = MAXSESSIONS;
 
-		pInfo->ulMinPinLen = 8;
-		pInfo->ulMaxPinLen = 8;
+		// L'applicazione deve chiedere solo la seconda meta' del PIN: la
+		// prima la antepone il modulo, leggendola dalla cache creata
+		// dall'abbinamento (IAS::GetFirstPIN). Dichiarando 8, Firefox
+		// rifiuta le 4 cifre corrette e accetta 8 cifre che diventano 12
+		// sulla carta, consumando un tentativo a ogni prova.
+		pInfo->ulMinPinLen = 4;
+		pInfo->ulMaxPinLen = 4;
 
 		pInfo->hardwareVersion.major = 0;
 		pInfo->hardwareVersion.minor = 0;

--- a/cie-pkcs11/Util/UUCByteArray.cpp
+++ b/cie-pkcs11/Util/UUCByteArray.cpp
@@ -111,7 +111,7 @@ UUCByteArray::~UUCByteArray()
 	//GlobalFree(m_pbtContent);
 	free(m_pbtContent);
 	if(m_szHex)
-		delete m_szHex;
+		delete[] m_szHex;
 }
 
 long UUCByteArray::load(const char* szHexString)
@@ -287,7 +287,7 @@ const char* UUCByteArray::toHexString(int nSize)
 {
 	if(m_szHex)
 	{
-		delete m_szHex;
+		delete[] m_szHex;
 		m_szHex = NULL;
 	}
 
@@ -312,7 +312,7 @@ const char* UUCByteArray::toHexString(int nSize)
 	}
 	catch(...)
 	{
-		delete m_szHex;
+		delete[] m_szHex;
 		m_szHex = NULL;
 		throw -3L;
 	}

--- a/cie_sign_sdk/src/ASN1/UUCByteArray.cpp
+++ b/cie_sign_sdk/src/ASN1/UUCByteArray.cpp
@@ -128,7 +128,7 @@ UUCByteArray::~UUCByteArray()
 	//GlobalFree(m_pbtContent);
 	free(m_pbtContent);
 	if(m_szHex)
-		delete m_szHex;
+		delete[] m_szHex;
 }
 
 void UUCByteArray::load(const char* szHexString)
@@ -300,7 +300,7 @@ const char* UUCByteArray::toHexString(int nSize)
 {
 	if(m_szHex)
 	{
-		delete m_szHex;
+		delete[] m_szHex;
 		m_szHex = NULL;
 	}
 


### PR DESCRIPTION
In diverse parti del codice, la memoria allocata con new[] viene liberata con delete e non con delete[].

m_szHex è allocato con new char[] in toHexString() e liberato con delete in tre punti. In questo caso il comportamento è indefinito.

Verificato con AddressSanitizer sul solo UUCByteArray, senza carta:
```
ERROR: AddressSanitizer: alloc-dealloc-mismatch
       (operator new [] vs operator delete)
  allocato:  toHexString(int):299   new char[(nSize+1)*2]
  liberato:  toHexString(int):290   delete m_szHex
  regione di 3328 byte
```
3328 = (0x67f + 1) * 2, il buffer per un certificato di 1663 byte.

Con glibc l'incoerenza passa inosservata (pkcs11-tool funziona). Chrome invece termina con SIGTRAP durante l'autenticazione: il log del modulo si interrompe fra In template e Out template della lettura di CKA_VALUE, l'unico attributo abbastanza grande da passare da toHexString. Dopo la correzione, sia il test ASan sia l'autenticazione da Chrome vanno a buon fine.

Ho apportato correzioni solo in UUCByteArray (vedi il messaggio sul commit https://github.com/italia/cie-middleware-linux/commit/8d9033f7074ade9c26de5d46695f6ba0ec84ace8 per individuare altre situazioni potenzialmente simili).

È stato anche corretto un bug relativo al tipo di firma utilizzato (DigestInfo di SHA-256 usava il prefisso di SHA-1).
Poiché il meccanismo usato per l'autenticazione client in TLS 1.2 è CKM_SHA256_RSA_PKCS, l'errore rendeva impossibile l'accesso ai servizi con la CIE dal browser (nel mio test il server non riceveva una firma valida e rispondeva
No_client_certificate).
Su Windows i browser usano il CSP anziché il modulo PKCS#11, il che spiega perché il difetto emerge solo su Linux.

Da ultimo ho corretto la lunghezza del PIN richiesto dall'applicazione (parametro utilizzato da Firefox). Per l'autenticazione serve sempre inserire solo le ultime 4 cifre del PIN e il modulo antepone le altre 4 per il confronto. La lunghezza del PIN richiesto dal browser era indicata in 8 e, con l'inserimento del PIN completo, l'autenticazione falliva (Chrome sembra ignorasse questa impostazione).
Con il prefisso corretto (RFC 8017 §9.2) la firma è identica byte per byte a quella prodotta da OpenSSL sugli stessi dati, e openssl dgst -sha256 -verify con la chiave pubblica letta dalla carta risponde Verified OK; prima rispondeva bad signature.

Con queste correzioni, nei miei test l'autenticazione (che utilizza TLS 1.2) su linux adesso funziona sia con Chrome sia con Firefox.
